### PR TITLE
fix: update import statements for Record type in filters and formats …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 fastapi>=0.99.1,<1.0.0
-beans-logging>=9.0.0,<10.0.0
+beans-logging>=9.0.2,<10.0.0

--- a/src/beans_logging_fastapi/filters.py
+++ b/src/beans_logging_fastapi/filters.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from loguru import Record
+else:
+    from beans_logging.typing import Record
 
 from beans_logging.filters import all_handlers_filter
 

--- a/src/beans_logging_fastapi/formats.py
+++ b/src/beans_logging_fastapi/formats.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from loguru import Record
+else:
+    from beans_logging.typing import Record
 
 
 def http_file_format(


### PR DESCRIPTION
This pull request updates the `beans_logging_fastapi` package to improve type handling and updates the `beans_logging` submodule. The most important changes are:

Type handling improvements:
* Updated imports in `filters.py` and `formats.py` to use the `Record` type from `beans_logging.typing` when not type checking, improving compatibility and clarity. [[1]](diffhunk://#diff-245c32547bf517e77643f84843e463c7c942a0c5ad4a1c3b40e6d32b2375ffe3R5-R6) [[2]](diffhunk://#diff-fcdbc8911909254d1ae56b4b91a1412d25129c97af6183f35aa3ae9b35444ea8R8-R9)

Dependency update:
* Updated the `beans_logging` submodule to a newer commit, which may include upstream bug fixes or features.