### PR TITLE
feat: update configuration loading to read all configs from directory…

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,10 +153,10 @@ from potato_util import io as io_utils
 from beans_logging_fastapi import LoggerConfigPM
 
 
-_config_path = os.path.join(os.getcwd(), "configs", "logger.yml")
 _config_data = {}
-if os.path.isfile(_config_path):
-    _config_data = io_utils.read_config_file(config_path=_config_path)
+_configs_dir = os.path.join(os.getcwd(), "configs")
+if os.path.isdir(_configs_dir):
+    _config_data = io_utils.read_all_configs(configs_dir=_configs_dir)
 
 
 class MainConfig(BaseSettings):

--- a/examples/config.py
+++ b/examples/config.py
@@ -6,10 +6,10 @@ from potato_util import io as io_utils
 from beans_logging_fastapi import LoggerConfigPM
 
 
-_config_path = os.path.join(os.getcwd(), "configs", "logger.yml")
 _config_data = {}
-if os.path.isfile(_config_path):
-    _config_data = io_utils.read_config_file(config_path=_config_path)
+_configs_dir = os.path.join(os.getcwd(), "configs")
+if os.path.isdir(_configs_dir):
+    _config_data = io_utils.read_all_configs(configs_dir=_configs_dir)
 
 
 class MainConfig(BaseSettings):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 fastapi>=0.99.1,<1.0.0
-beans-logging>=9.0.2,<10.0.0
+beans-logging>=9.1.0,<10.0.0


### PR DESCRIPTION
This pull request updates the configuration loading logic to support loading all configuration files from a directory, rather than a single file, and updates the `beans_logging` submodule to a new commit. The changes improve flexibility in configuration management.

Configuration loading improvements:

* Changed the logic in both `README.md` and `examples/config.py` to load all configuration files from the `configs` directory using `io_utils.read_all_configs`, instead of loading only a single `logger.yml` file. This enhances support for multiple configuration files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L156-R159) [[2]](diffhunk://#diff-76625f0dbd8716366ca55d52d943875e92ee5f578ec450e0505a92334f47709bL9-R12)

Dependency update:

* Updated the `beans_logging` submodule to a new commit (`3d37127a`), which may include bug fixes or new features.