### PR TITLE
fix: update beans-logging version and changed async log to sync log i…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 fastapi>=0.99.1,<1.0.0
-beans-logging>=9.1.0,<10.0.0
+beans-logging>=9.1.1,<10.0.0

--- a/src/beans_logging_fastapi/middlewares.py
+++ b/src/beans_logging_fastapi/middlewares.py
@@ -4,7 +4,8 @@ from typing import Any
 from collections.abc import Callable
 
 from fastapi import Request, Response
-from fastapi.concurrency import run_in_threadpool
+
+# from fastapi.concurrency import run_in_threadpool
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from beans_logging import logger
@@ -284,16 +285,16 @@ class HttpAccessLogMiddleware(BaseHTTPMiddleware):
         if self.use_debug_log:
             _debug_msg = self.debug_msg_format_str.format(**_http_info)
 
-            # _logger.bind(
-            #     http_info=_http_info, disable_http_all_file_handlers=True
-            # ).debug(_debug_msg)
-            await run_in_threadpool(
-                _logger.bind(
-                    http_info=_http_info, disable_http_all_file_handlers=True
-                ).debug,
-                _debug_msg,
-            )
-        # Debug log
+            _logger.bind(
+                http_info=_http_info, disable_http_all_file_handlers=True
+            ).debug(_debug_msg)
+            # await run_in_threadpool(
+            #     _logger.bind(
+            #         http_info=_http_info, disable_http_all_file_handlers=True
+            #     ).debug,
+            #     _debug_msg,
+            # )
+        # Debug log.
 
         # Process request:
         response: Response = await call_next(request)
@@ -328,9 +329,9 @@ class HttpAccessLogMiddleware(BaseHTTPMiddleware):
             )
 
         _msg = _msg_format_str.format(**_http_info)
-        # _logger.bind(http_info=_http_info).log(_LEVEL, _msg)
-        await run_in_threadpool(_logger.bind(http_info=_http_info).log, _LEVEL, _msg)
-        # Http access log
+        _logger.bind(http_info=_http_info).log(_LEVEL, _msg)
+        # await run_in_threadpool(_logger.bind(http_info=_http_info).log, _LEVEL, _msg)
+        # Http access log.
 
         return response
 


### PR DESCRIPTION
This pull request updates the logging middleware in `src/beans_logging_fastapi/middlewares.py` to simplify and streamline how logging is handled for FastAPI requests. The main change is the removal of asynchronous threadpool logging, making all log calls synchronous, which should improve clarity and maintainability.

Logging middleware simplification:

* Replaced asynchronous logging using `run_in_threadpool` with direct synchronous log calls for both debug and access logs in the `dispatch` method. [[1]](diffhunk://#diff-94466bff29afefd5127f0edc630049ee003f64a8122d17606f19340526fa35d1L287-R297) [[2]](diffhunk://#diff-94466bff29afefd5127f0edc630049ee003f64a8122d17606f19340526fa35d1L331-R334)
* Commented out the import of `run_in_threadpool` from `fastapi.concurrency`, reflecting its removal from the middleware logic.

Dependency update:

* Updated the beans logging submodule to a new commit, which may include upstream improvements or bug fixes.