### PR TITLE
feat!: removed 'default' option to simplify configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,8 @@ To use `beans_logging_fastapi`:
 ```yaml
 logger:
   app_name: "fastapi-app"
-  default:
-    level:
-      base: TRACE
+  level:
+    base: TRACE
   http:
     std:
       format_str: '<n><w>[{request_id}]</w></n> {client_host} {user_id} "<u>{method} {url_path}</u> HTTP/{http_version}" {status_code} {content_length}B {response_time}ms'
@@ -381,18 +380,17 @@ uvicorn main:app --host=0.0.0.0 --port=8000
 ```yaml
 logger:
   # app_name: fastapi-app
-  default:
-    level:
-      base: INFO
-      err: WARNING
-    format_str: "[{time:YYYY-MM-DD HH:mm:ss.SSS Z} | {extra[level_short]:<5} | {name}:{line}]: {message}"
-    file:
-      logs_dir: "./logs"
-      rotate_size: 10000000
-      rotate_time: "00:00:00"
-      retention: 90
-      encoding: utf8
-    use_custom_serialize: false
+  level:
+    base: INFO
+    err: WARNING
+  format_str: "[{time:YYYY-MM-DD HH:mm:ss.SSS Z} | {extra[level_short]:<5} | {name}:{line}]: {message}"
+  file:
+    logs_dir: "./logs"
+    rotate_size: 10000000
+    rotate_time: "00:00:00"
+    retention: 90
+    encoding: utf8
+  use_custom_serialize: false
   http:
     std:
       msg_format_str: '<n><w>[{request_id}]</w></n> {client_host} {user_id} "<u>{method} {url_path}</u> HTTP/{http_version}" {status_code} {content_length}B {response_time}ms'

--- a/examples/configs/logger.yml
+++ b/examples/configs/logger.yml
@@ -1,9 +1,8 @@
 logger:
   app_name: "fastapi-app"
-  default:
-    level:
-      base: TRACE
-    format_str: "[{time:YYYY-MM-DD HH:mm:ss.SSS Z} | {extra[level_short]:<5} | {name}:{line}]: {message}"
+  level:
+    base: TRACE
+  format_str: "[{time:YYYY-MM-DD HH:mm:ss.SSS Z} | {extra[level_short]:<5} | {name}:{line}]: {message}"
   http:
     std:
       msg_format_str: '<n><w>[{request_id}]</w></n> {client_host} {user_id} "<u>{method} {url_path}</u> HTTP/{http_version}" {status_code} {content_length}B {response_time}ms'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 fastapi>=0.99.1,<1.0.0
-beans-logging>=9.1.1,<10.0.0
+beans-logging>=10.0.0,<11.0.0

--- a/templates/configs/config.yml
+++ b/templates/configs/config.yml
@@ -1,17 +1,16 @@
 logger:
   # app_name: fastapi-app
-  default:
-    level:
-      base: INFO
-      err: WARNING
-    format_str: "[{time:YYYY-MM-DD HH:mm:ss.SSS Z} | {extra[level_short]:<5} | {name}:{line}]: {message}"
-    file:
-      logs_dir: "./logs"
-      rotate_size: 10000000
-      rotate_time: "00:00:00"
-      retention: 90
-      encoding: utf8
-    use_custom_serialize: false
+  level:
+    base: INFO
+    err: WARNING
+  format_str: "[{time:YYYY-MM-DD HH:mm:ss.SSS Z} | {extra[level_short]:<5} | {name}:{line}]: {message}"
+  file:
+    logs_dir: "./logs"
+    rotate_size: 10000000
+    rotate_time: "00:00:00"
+    retention: 90
+    encoding: utf8
+  use_custom_serialize: false
   http:
     std:
       msg_format_str: '<n><w>[{request_id}]</w></n> {client_host} {user_id} "<u>{method} {url_path}</u> HTTP/{http_version}" {status_code} {content_length}B {response_time}ms'


### PR DESCRIPTION
This pull request primarily updates logger configuration files by removing the `default` key from logger sections, simplifying the YAML structure. Additionally, it updates the `beans_logging` submodule to a newer commit. These changes improve configuration consistency and ensure compatibility with the latest logging module version.

Logger configuration simplification:

* Removed the `default` key from logger sections in `README.md`, `examples/configs/logger.yml`, and `templates/configs/config.yml` to streamline the YAML structure and align with updated logging practices. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L384) [[3]](diffhunk://#diff-61a730c9a3ae725bdd6a37a13617dd6e481ff9658f8d038abe4df0ed7c7941caL3) [[4]](diffhunk://#diff-0749353e11b28f729e9f97bec98faf39e7cb132035da5b0899ba35a4bfe07c36L3)

Dependency update:

* Updated the `beans_logging` submodule in `src/modules/beans_logging` to a newer commit for improved features and compatibility.