### PR TITLE
feat: update beans-logging version and add async HTTP error logging f…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 fastapi>=0.99.1,<1.0.0
-beans-logging>=10.0.0,<11.0.0
+beans-logging>=10.0.1,<11.0.0

--- a/src/beans_logging_fastapi/__init__.py
+++ b/src/beans_logging_fastapi/__init__.py
@@ -3,10 +3,13 @@ from beans_logging import logger
 from .__version__ import __version__
 from .config import LoggerConfigPM
 from ._core import add_logger
+from .http_error import async_log_http_error, log_http_error
 
 __all__ = [
     "__version__",
     "logger",
     "add_logger",
     "LoggerConfigPM",
+    "async_log_http_error",
+    "log_http_error",
 ]

--- a/src/beans_logging_fastapi/_async.py
+++ b/src/beans_logging_fastapi/_async.py
@@ -1,42 +1,7 @@
-from typing import Any
-
 from pydantic import validate_call
-from fastapi import Request
 from fastapi.concurrency import run_in_threadpool
 
-from beans_logging import logger, Logger
-
-
-@validate_call(config={"arbitrary_types_allowed": True})
-async def async_log_http_error(
-    request: Request,
-    status_code: int,
-    msg_format_str: str = (
-        '<n><w>[{request_id}]</w></n> {client_host} {user_id} "<u>{method} {url_path}</u>'
-        ' HTTP/{http_version}" <n>{status_code}</n>'
-    ),
-) -> None:
-    """Log HTTP error for unhandled Exception.
-
-    Args:
-        request        (Request, required): Request instance.
-        status_code    (int    , required): HTTP status code.
-        msg_format_str (str    , optional): Message format. Defaults to
-            '<n><w>[{request_id}]</w></n> {client_host} {user_id} "<u>{method} {url_path}</u> HTTP/{http_version}"
-                <n>{status_code}</n>'.
-    """
-
-    _http_info: dict[str, Any] = {"request_id": request.state.request_id}
-    if hasattr(request.state, "http_info") and isinstance(
-        request.state.http_info, dict
-    ):
-        _http_info: dict[str, Any] = request.state.http_info
-    _http_info["status_code"] = status_code
-
-    _msg = msg_format_str.format(**_http_info)
-    _logger: Logger = logger.opt(colors=True, record=True).bind(http_info=_http_info)
-    await run_in_threadpool(_logger.error, _msg)
-    return
+from beans_logging import logger
 
 
 @validate_call
@@ -137,7 +102,6 @@ async def async_log_level(level: str, message: str) -> None:
 
 
 __all__ = [
-    "async_log_http_error",
     "async_log_trace",
     "async_log_debug",
     "async_log_info",

--- a/src/beans_logging_fastapi/filters.py
+++ b/src/beans_logging_fastapi/filters.py
@@ -2,8 +2,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from loguru import Record
-else:
-    from beans_logging.typing import Record
 
 from beans_logging.filters import all_handlers_filter
 

--- a/src/beans_logging_fastapi/formats.py
+++ b/src/beans_logging_fastapi/formats.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from loguru import Record
-else:
-    from beans_logging.typing import Record
 
 
 def http_file_format(

--- a/src/beans_logging_fastapi/http_error.py
+++ b/src/beans_logging_fastapi/http_error.py
@@ -1,0 +1,77 @@
+from typing import Any
+
+from pydantic import validate_call
+from fastapi import Request
+from fastapi.concurrency import run_in_threadpool
+
+from beans_logging import logger, Logger
+
+
+@validate_call(config={"arbitrary_types_allowed": True})
+async def async_log_http_error(
+    request: Request,
+    status_code: int,
+    msg_format_str: str = (
+        '<n><w>[{request_id}]</w></n> {client_host} {user_id} "<u>{method} {url_path}</u>'
+        ' HTTP/{http_version}" <n>{status_code}</n>'
+    ),
+) -> None:
+    """Async Log HTTP error for unhandled Exception.
+
+    Args:
+        request        (Request, required): Request instance.
+        status_code    (int    , required): HTTP status code.
+        msg_format_str (str    , optional): Message format. Defaults to
+            '<n><w>[{request_id}]</w></n> {client_host} {user_id} "<u>{method} {url_path}</u> HTTP/{http_version}"
+                <n>{status_code}</n>'.
+    """
+
+    _http_info: dict[str, Any] = {"request_id": request.state.request_id}
+    if hasattr(request.state, "http_info") and isinstance(
+        request.state.http_info, dict
+    ):
+        _http_info: dict[str, Any] = request.state.http_info
+    _http_info["status_code"] = status_code
+
+    _msg = msg_format_str.format(**_http_info)
+    _logger: Logger = logger.opt(colors=True, record=True).bind(http_info=_http_info)
+    await run_in_threadpool(_logger.error, _msg)
+    return
+
+
+@validate_call(config={"arbitrary_types_allowed": True})
+def log_http_error(
+    request: Request,
+    status_code: int,
+    msg_format_str: str = (
+        '<n><w>[{request_id}]</w></n> {client_host} {user_id} "<u>{method} {url_path}</u>'
+        ' HTTP/{http_version}" <n>{status_code}</n>'
+    ),
+) -> None:
+    """Log HTTP error for unhandled Exception.
+
+    Args:
+        request        (Request, required): Request instance.
+        status_code    (int    , required): HTTP status code.
+        msg_format_str (str    , optional): Message format. Defaults to
+            '<n><w>[{request_id}]</w></n> {client_host} {user_id} "<u>{method} {url_path}</u> HTTP/{http_version}"
+                <n>{status_code}</n>'.
+    """
+
+    _http_info: dict[str, Any] = {"request_id": request.state.request_id}
+    if hasattr(request.state, "http_info") and isinstance(
+        request.state.http_info, dict
+    ):
+        _http_info: dict[str, Any] = request.state.http_info
+    _http_info["status_code"] = status_code
+
+    _msg = msg_format_str.format(**_http_info)
+    _logger: Logger = logger.opt(colors=True, record=True).bind(http_info=_http_info)
+    _logger.error(_msg)
+    return
+
+
+__all__ = [
+    "async_log_http_error",
+    "log_http_error",
+]


### PR DESCRIPTION
This pull request refactors how HTTP error logging is handled in the `beans_logging_fastapi` package by moving the logging functions into a new module, improving code organization, and updating imports accordingly. It also makes minor improvements to type checking imports in filter and format modules.

**HTTP Error Logging Refactor:**

* Extracted `async_log_http_error` from `_async.py` and added a new synchronous `log_http_error` function; both are now implemented in a new `http_error.py` module for clearer separation of concerns. (`src/beans_logging_fastapi/http_error.py`, [src/beans_logging_fastapi/http_error.pyR1-R77](diffhunk://#diff-18f059bb2b4edcbf1f2347a44ee2be309b3e3ea8ef79da2e289b9b659b536196R1-R77))
* Updated the package's public API in `__init__.py` to export the new logging functions, ensuring they are accessible for users.
* Removed the old `async_log_http_error` implementation from `_async.py` and updated its `__all__` accordingly. [[1]](diffhunk://#diff-27a3ade4d1dbe3211c1e652665529b72b34500c69644c0a63efa4ac4b39374bdL1-R4) [[2]](diffhunk://#diff-27a3ade4d1dbe3211c1e652665529b72b34500c69644c0a63efa4ac4b39374bdL140)

**Type Checking and Imports:**

* Cleaned up type checking imports in `filters.py` and `formats.py` by removing unnecessary imports of the `Record` type from `beans_logging.typing`, relying solely on the type from `loguru` when type checking. [[1]](diffhunk://#diff-245c32547bf517e77643f84843e463c7c942a0c5ad4a1c3b40e6d32b2375ffe3L5-L6) [[2]](diffhunk://#diff-fcdbc8911909254d1ae56b4b91a1412d25129c97af6183f35aa3ae9b35444ea8L8-L9)

**Submodule Update:**

* Updated the `beans_logging` submodule to a new commit, which may bring in upstream changes or fixes.