### PR TITLE
fix: update has_proxy_headers and has_cf_headers to true in configura…

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ logger:
     file:
       format_str: '{client_host} {request_id} {user_id} [{datetime}] "{method} {url_path} HTTP/{http_version}" {status_code} {content_length} "{h_referer}" "{h_user_agent}" {response_time}'
       tz: "localtime"
-    has_proxy_headers: false
-    has_cf_headers: false
+    has_proxy_headers: true
+    has_cf_headers: true
   intercept:
     mute_modules: ["uvicorn.access"]
   handlers:
@@ -398,8 +398,8 @@ logger:
     file:
       format_str: '{client_host} {request_id} {user_id} [{datetime}] "{method} {url_path} HTTP/{http_version}" {status_code} {content_length} "{h_referer}" "{h_user_agent}" {response_time}'
       tz: localtime
-    has_proxy_headers: false
-    has_cf_headers: false
+    has_proxy_headers: true
+    has_cf_headers: true
   intercept:
     enabled: true
     only_base: false

--- a/src/beans_logging_fastapi/config.py
+++ b/src/beans_logging_fastapi/config.py
@@ -110,8 +110,8 @@ class FileConfigPM(ExtraBaseModel):
 class HttpConfigPM(ExtraBaseModel):
     std: StdConfigPM = Field(default_factory=StdConfigPM)
     file: FileConfigPM = Field(default_factory=FileConfigPM)
-    has_proxy_headers: bool = Field(default=False)
-    has_cf_headers: bool = Field(default=False)
+    has_proxy_headers: bool = Field(default=True)
+    has_cf_headers: bool = Field(default=True)
 
 
 class LoggerConfigPM(BaseLoggerConfigPM):

--- a/templates/configs/config.yml
+++ b/templates/configs/config.yml
@@ -19,8 +19,8 @@ logger:
     file:
       format_str: '{client_host} {request_id} {user_id} [{datetime}] "{method} {url_path} HTTP/{http_version}" {status_code} {content_length} "{h_referer}" "{h_user_agent}" {response_time}'
       tz: localtime
-    has_proxy_headers: false
-    has_cf_headers: false
+    has_proxy_headers: true
+    has_cf_headers: true
   intercept:
     enabled: true
     only_base: false


### PR DESCRIPTION
This pull request updates the default logger configuration to enable support for proxy and Cloudflare headers. The changes ensure that log entries will now include information from these headers, improving visibility and traceability in environments using proxies or Cloudflare.

Logger configuration updates:

* Changed `has_proxy_headers` and `has_cf_headers` defaults from `false` to `true` in the `logger:` sections of `README.md` and `templates/configs/config.yml`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-R120) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L401-R402) [[3]](diffhunk://#diff-0749353e11b28f729e9f97bec98faf39e7cb132035da5b0899ba35a4bfe07c36L22-R23)
* Updated the `HttpConfigPM` class in `src/beans_logging_fastapi/config.py` to set `has_proxy_headers` and `has_cf_headers` default values to `True`.