### PR TITLE
fix: update beans-logging version to 10.0.3 and subproject commit ref…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 fastapi>=0.99.1,<1.0.0
-beans-logging>=10.0.1,<11.0.0
+beans-logging>=10.0.3,<11.0.0


### PR DESCRIPTION
This pull request updates the `beans_logging` submodule to a newer commit. This is a routine update to ensure the project uses the latest version of the logging module.