### PR TITLE
fix: add log_at to beans_logging exports

### DIFF
--- a/src/beans_logging_fastapi/__init__.py
+++ b/src/beans_logging_fastapi/__init__.py
@@ -1,4 +1,4 @@
-from beans_logging import logger, LogLevelEnum
+from beans_logging import logger, LogLevelEnum, log_at
 
 from .__version__ import __version__
 from .config import LoggerConfigPM
@@ -14,5 +14,6 @@ __all__ = [
     "LoggerConfigPM",
     "async_log_http_error",
     "log_http_error",
+    "log_at",
     "async_log_at",
 ]


### PR DESCRIPTION
This pull request updates the `beans_logging_fastapi` package to improve logging functionality and maintain compatibility with the underlying `beans_logging` module. The most important changes are summarized below:

### Logging Functionality Enhancements

* Exposed the `log_at` function from `beans_logging` in the `beans_logging_fastapi` package by importing it in `src/beans_logging_fastapi/__init__.py` and adding it to the `__all__` list, making it available for users of the package. [[1]](diffhunk://#diff-e3dd59c28d75ed46be923c5e73cd0123ddf4923f0abc755db74069bf9ebe6456L1-R1) [[2]](diffhunk://#diff-e3dd59c28d75ed46be923c5e73cd0123ddf4923f0abc755db74069bf9ebe6456R17)

### Dependency Update

* Updated the `beans_logging` submodule to the latest commit, ensuring the package uses the most recent features and bug fixes from the logging library.