### PR TITLE
fix: correct parameter name in logger binding for HTTP error logging

### DIFF
--- a/src/beans_logging_fastapi/http_error.py
+++ b/src/beans_logging_fastapi/http_error.py
@@ -35,7 +35,7 @@ async def async_log_http_error(
 
     _msg = msg_format_str.format(**_http_info)
     _logger: Logger = logger.opt(colors=True, record=True).bind(
-        http_info=_http_info, disable_all_std_handler=True
+        http_info=_http_info, disable_std_handler=True
     )
     await run_in_threadpool(_logger.error, _msg)
     return
@@ -69,7 +69,7 @@ def log_http_error(
 
     _msg = msg_format_str.format(**_http_info)
     _logger: Logger = logger.opt(colors=True, record=True).bind(
-        http_info=_http_info, disable_all_std_handler=True
+        http_info=_http_info, disable_std_handler=True
     )
     _logger.error(_msg)
     return


### PR DESCRIPTION
This pull request makes a minor adjustment to the logging configuration for HTTP error logging in the `src/beans_logging_fastapi/http_error.py` file. The change updates the logger binding parameter to improve clarity and consistency.

Logging configuration update:

* Changed the logger binding parameter from `disable_all_std_handler` to `disable_std_handler` in both `async_log_http_error` and `log_http_error` functions for improved naming consistency. [[1]](diffhunk://#diff-18f059bb2b4edcbf1f2347a44ee2be309b3e3ea8ef79da2e289b9b659b536196L38-R38) [[2]](diffhunk://#diff-18f059bb2b4edcbf1f2347a44ee2be309b3e3ea8ef79da2e289b9b659b536196L72-R72)