### PR TITLE
fix: increase logger binding depth for improved context in HTTP error…

### DIFF
--- a/src/beans_logging_fastapi/http_error.py
+++ b/src/beans_logging_fastapi/http_error.py
@@ -68,7 +68,7 @@ def log_http_error(
     _http_info["status_code"] = status_code
 
     _msg = msg_format_str.format(**_http_info)
-    _logger: Logger = logger.opt(colors=True, record=True).bind(
+    _logger: Logger = logger.opt(colors=True, record=True, depth=3).bind(
         http_info=_http_info, disable_std_handler=True
     )
     _logger.error(_msg)


### PR DESCRIPTION
This pull request makes a minor adjustment to the logging configuration in the `log_http_error` function. The change increases the stack trace depth for error logs, which can help with debugging by providing more context in log entries.

* Logging configuration: Updated the `logger.opt()` call in `src/beans_logging_fastapi/http_error.py` to include `depth=3`, increasing the stack trace depth for error logs.